### PR TITLE
chain: api WaitMined use abstract contract transaction instead of raw…

### DIFF
--- a/chain/eth/chain.go
+++ b/chain/eth/chain.go
@@ -299,8 +299,8 @@ func (c *ChainEthereum) getSkillContract(addr []byte) (*ConsumeSkill, error) {
 }
 
 //WaitMined blocks the caller until the transaction is mined, or gets an error
-func (c *ChainEthereum) WaitMined(ctx context.Context, tx interface{}) error {
-	receipt, err := bind.WaitMined(ctx, c.deployBackend, tx.(*types.Transaction))
+func (c *ChainEthereum) WaitMined(ctx context.Context, trans *transaction.ContractTransaction) error {
+	receipt, err := bind.WaitMined(ctx, c.deployBackend, trans.RawTx().(*types.Transaction))
 	if err != nil {
 		return fmt.Errorf("wait mined returns error:%v", err)
 	}

--- a/chain/eth/chain_test.go
+++ b/chain/eth/chain_test.go
@@ -78,7 +78,7 @@ func TestConsumeSkillContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("transaction sent to block chain")
-	err = chain.WaitMined(context.Background(), ct.RawTx())
+	err = chain.WaitMined(context.Background(), ct)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestConsumeContentContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("transaction sent to block chain")
-	err = chain.WaitMined(context.Background(), ct.RawTx())
+	err = chain.WaitMined(context.Background(), ct)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestConsumeContentContract(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to send raw tx", err)
 	}
-	err = chain.WaitMined(context.Background(), ct.RawTx())
+	err = chain.WaitMined(context.Background(), ct)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestConsumeContentContractOnPrivateChain(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("transaction sent to block chain")
-	err = blc.WaitMined(context.Background(), ct.RawTx())
+	err = blc.WaitMined(context.Background(), ct)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,9 +332,21 @@ func TestConsumeContentContractOnPrivateChain(t *testing.T) {
 
 	transOpts := bind.NewKeyedTransactor(owner.PrivateKey)
 	transOpts.Value = new(big.Int).SetUint64(uint64(contractData.PPrice))
-	transOpts.GasLimit = 200000
-	tx, err := sc.Consume(transOpts)
-	err = blc.WaitMined(context.Background(), tx)
+	transOpts.GasLimit = 2000001
+	var emptyCallData interface{} //consum method needs no input
+	ct, err = blc.Call(context.Background(), ownerAddr.Bytes(), "Content", contractAddr, "consume", transOpts.Value, emptyCallData)
+	if err != nil {
+		t.Fatal("failed to call method", err)
+	}
+	sig, err = crypto.Sign(ct.Hash(), owner.PrivateKey)
+	if err != nil {
+		t.Fatal("failed to sign raw tx", err)
+	}
+	err = blc.ConfirmTrans(context.Background(), ct, sig)
+	if err != nil {
+		t.Fatal("failed to send raw tx", err)
+	}
+	err = blc.WaitMined(context.Background(), ct)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/provider.go
+++ b/chain/provider.go
@@ -14,7 +14,7 @@ type Chain interface {
 	NewContract(ctx context.Context, from []byte, contractType string, contractData interface{}) (*transaction.ContractTransaction, error)
 	Call(ctx context.Context, from []byte, contractType string, contractAddr []byte, methodName string, value *big.Int, callData interface{}) (*transaction.ContractTransaction, error)
 	ConfirmTrans(ctx context.Context, trans *transaction.ContractTransaction, sig []byte) error
-	WaitMined(ctx context.Context, tx interface{}) error
+	WaitMined(ctx context.Context, trans *transaction.ContractTransaction) error
 	BalanceAt(ctx context.Context, addr []byte) (*big.Int, error)
 	PubKeyToAddress(pub *ecdsa.PublicKey) []byte
 }

--- a/examples/consume_content/main.go
+++ b/examples/consume_content/main.go
@@ -79,7 +79,7 @@ func main() {
 		if err != nil {
 			log.Fatal("failed to confirm contract creation transaction")
 		}
-		if err = chain.WaitMined(context.Background(), trans.RawTx()); err != nil {
+		if err = chain.WaitMined(context.Background(), trans); err != nil {
 			log.Fatal("error happen when wait transaction mined", err)
 		}
 		log.Printf("smart contract deployed to address:%v\n", common.BytesToHash(addr).Hex())
@@ -117,7 +117,7 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to confirm contract creation transaction")
 	}
-	if err = chain.WaitMined(context.Background(), trans.RawTx()); err != nil {
+	if err = chain.WaitMined(context.Background(), trans); err != nil {
 		log.Fatal("error happen when wait transaction mined", err)
 	}
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -58,7 +58,7 @@ func main() {
 	fmt.Println("mining")
 	simBackend.Commit()
 
-	simChain.WaitMined(context.Background(), ct.RawTx())
+	simChain.WaitMined(context.Background(), ct)
 	log.Printf("smart contract deployed to address:%v\n", ct.ContractAddr)
 
 	ctr, err := simChain.GetContract(ct.ContractAddr, string(chain.ContentContractType))

--- a/examples/watch_event/main.go
+++ b/examples/watch_event/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"reflect"
 
+	"github.com/icstglobal/go-icst/transaction"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
@@ -82,7 +84,7 @@ func main() {
 		log.Fatal(err)
 	}
 	log.Println("transaction sent to block chain")
-	err = blc.WaitMined(context.Background(), ct.RawTx())
+	err = blc.WaitMined(context.Background(), ct)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -113,7 +115,8 @@ func main() {
 	transOpts.Value = new(big.Int).SetUint64(uint64(contractData.PPrice))
 	transOpts.GasLimit = 200000
 	tx, err := sc.Consume(transOpts)
-	err = blc.WaitMined(context.Background(), tx)
+	ctConsume := transaction.NewContractTransaction(tx, ownerAddr.Bytes())
+	err = blc.WaitMined(context.Background(), ctConsume)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
uniform the chain API's parameter type, all transactions are type of abstract contract transaction, instead of underlying raw transaction. All tests and examples code changed.